### PR TITLE
adds API endpoint for prometheus SD for IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Lists are returned as JSON arrays or as plain text. This means that firewalls
 can use NetBox as a source for dynamic address lists, such as Palo Alto's External Dynamic Lists, Fortinet's External Block List (Threat Feed) or
 pfSesnse/OPNSense's firewall aliases.
 
-This plugin also features endpoints for devices/VMs compatible with Prometheus' http_sd.
+This plugin also features endpoints for devices/VMs/IP addresses compatible with Prometheus' http_sd.
 
 This plugin supports NetBox v3.0, v3.1, v3.2, v3.3, and v3.4.
 
@@ -121,6 +121,22 @@ PLUGINS_CONFIG = {
             "__meta_netbox_serial": ("serial",),
             # A custom field. Will be an empty string if None.
             # "__meta_netbox_fqdn": ("cf", "fqdn"),
+        },
+        # Tuple/list of attributes to use for Prometheus IP address SD target. Defaults are shown.
+        #
+        # If all attributes return None, the address in CIDR format will be used.
+        "prometheus_ipaddress_sd_target": (
+            ("address", "ip"),
+        ),
+        # Dictionary of label to IP address attribute for Prometheus ip address SD. Defaults are shown.
+        "prometheus_ipaddress_sd_labels": {
+            "__meta_netbox_id": ("id",),
+            "__meta_netbox_role": ("role",),
+            "__meta_netbox_dns_name": ("dns_name",),
+            "__meta_netbox_status": ("status",),
+            # For addresses assigned to interfaces
+            #"__meta_netbox_device": ("assigned_object", "device", "name"),
+            #"__meta_netbox_interface": ("assigned_object", "name"),
         },
     }
 }

--- a/netbox_lists/__init__.py
+++ b/netbox_lists/__init__.py
@@ -58,6 +58,15 @@ class ListsPluginConfig(PluginConfig):
             "__meta_netbox_primary_ip6": ("primary_ip6", "address", "ip"),
             "__meta_netbox_serial": ("serial",),
         },
+        "prometheus_ipaddress_sd_target": (
+            ("address", "ip"),
+        ),
+        "prometheus_ipaddress_sd_labels": {
+            "__meta_netbox_id": ("id",),
+            "__meta_netbox_role": ("role",),
+            "__meta_netbox_dns_name": ("dns_name",),
+            "__meta_netbox_status": ("status",),
+        },
     }
 
 

--- a/netbox_lists/__init__.py
+++ b/netbox_lists/__init__.py
@@ -58,9 +58,7 @@ class ListsPluginConfig(PluginConfig):
             "__meta_netbox_primary_ip6": ("primary_ip6", "address", "ip"),
             "__meta_netbox_serial": ("serial",),
         },
-        "prometheus_ipaddress_sd_target": (
-            ("address", "ip"),
-        ),
+        "prometheus_ipaddress_sd_target": (("address", "ip"),),
         "prometheus_ipaddress_sd_labels": {
             "__meta_netbox_id": ("id",),
             "__meta_netbox_role": ("role",),

--- a/netbox_lists/api/serializers.py
+++ b/netbox_lists/api/serializers.py
@@ -3,6 +3,7 @@ from typing import Dict, Generic, List, TypeVar
 
 from dcim.models import Device
 from django.conf import settings
+from ipam.models import IPAddress
 from rest_framework import serializers
 from utilities.exceptions import AbortRequest
 from virtualization.models import VirtualMachine
@@ -16,13 +17,15 @@ class BasePrometheusSerializer(serializers.Serializer, Generic[T]):
     targets = serializers.SerializerMethodField()
     labels = serializers.SerializerMethodField()
 
+    default_target_attr = "name"
+
     def get_targets(self, device: T) -> List[str]:
-        # Default to Name
+        # Default to default_target_attr
         for attrs in chain(
             settings.PLUGINS_CONFIG["netbox_lists"][
                 f"prometheus_{self.settings_type}_sd_target"
             ],
-            (("name",),),
+            ((self.default_target_attr,),),
         ):
             print(f"Attr: {repr(attrs)}")
             target = get_attr(attrs, device)
@@ -51,3 +54,8 @@ class PrometheusVMSerializer(BasePrometheusSerializer[VirtualMachine]):
 
 class PrometheusDeviceSerializer(BasePrometheusSerializer[Device]):
     settings_type = "device"
+
+
+class PrometheusIPAddressSerializer(BasePrometheusSerializer[IPAddress]):
+    settings_type = "ipaddress"
+    default_target_attr = "address"

--- a/netbox_lists/api/urls.py
+++ b/netbox_lists/api/urls.py
@@ -11,6 +11,7 @@ from .views import (
     PrefixListViewSet,
     PrometheusDeviceSD,
     PrometheusVirtualMachineSD,
+    PrometheusIPAddressSD,
     ServiceListviewSet,
     TagsListViewSet,
     VirtualMachinesListViewSet,
@@ -33,6 +34,7 @@ router.register(
 )
 router.register("prometheus-devices", PrometheusDeviceSD)
 router.register("prometheus-vms", PrometheusVirtualMachineSD)
+router.register("prometheus-ip-addresses", PrometheusIPAddressSD)
 
 router.register("devices-vms", DevicesVMsListViewSet)
 router.register("devices-vms-attrs", DevicesVMsAttrsListViewSet)

--- a/netbox_lists/api/views.py
+++ b/netbox_lists/api/views.py
@@ -38,7 +38,11 @@ from virtualization.models import VirtualMachine
 from .constants import AS_CIDR_PARAM_NAME, FAMILY_PARAM_NAME, SUMMARIZE_PARAM_NAME
 from .filtersets import CustomPrefixFilterSet
 from .renderers import PlainTextRenderer
-from .serializers import PrometheusDeviceSerializer, PrometheusIPAddressSerializer, PrometheusVMSerializer
+from .serializers import (
+    PrometheusDeviceSerializer,
+    PrometheusIPAddressSerializer,
+    PrometheusVMSerializer,
+)
 from .utils import (
     device_vm_primary_list,
     filter_queryset,

--- a/netbox_lists/api/views.py
+++ b/netbox_lists/api/views.py
@@ -38,7 +38,7 @@ from virtualization.models import VirtualMachine
 from .constants import AS_CIDR_PARAM_NAME, FAMILY_PARAM_NAME, SUMMARIZE_PARAM_NAME
 from .filtersets import CustomPrefixFilterSet
 from .renderers import PlainTextRenderer
-from .serializers import PrometheusDeviceSerializer, PrometheusVMSerializer
+from .serializers import PrometheusDeviceSerializer, PrometheusIPAddressSerializer, PrometheusVMSerializer
 from .utils import (
     device_vm_primary_list,
     filter_queryset,
@@ -652,6 +652,14 @@ class PrometheusVirtualMachineSD(
     queryset = VirtualMachine.objects.filter()
     filterset_class = VirtualMachineFilterSet
     serializer_class = PrometheusVMSerializer
+
+
+class PrometheusIPAddressSD(
+    InvalidFilterCheckMixin, mixins.ListModelMixin, ListsBaseViewSet
+):
+    queryset = IPAddress.objects.filter()
+    filterset_class = IPAddressFilterSet
+    serializer_class = PrometheusIPAddressSerializer
 
 
 class DevicesVMsAttrsListViewSet(ListsBaseViewSet):

--- a/tests/files/plugins.py
+++ b/tests/files/plugins.py
@@ -37,7 +37,7 @@ PLUGINS_CONFIG = {
             # A custom field. Will be an empty string if None.
             "__meta_netbox_fqdn": ("cf", "fqdn"),
         },
-        "prometheus_ipaddres_sd_labels": {
+        "prometheus_ipaddress_sd_labels": {
             "__meta_netbox_id": ("id",),
             "__meta_netbox_role": ("role",),
             "__meta_netbox_status": ("status",),

--- a/tests/files/plugins.py
+++ b/tests/files/plugins.py
@@ -37,5 +37,12 @@ PLUGINS_CONFIG = {
             # A custom field. Will be an empty string if None.
             "__meta_netbox_fqdn": ("cf", "fqdn"),
         },
+        "prometheus_ipaddres_sd_labels": {
+            "__meta_netbox_id": ("id",),
+            "__meta_netbox_role": ("role",),
+            "__meta_netbox_status": ("status",),
+            "__meta_netbox_dns_name": ("dns_name",),
+            "__meta_netbox_assigned": ("assigned_object", "name"),
+        },
     }
 }

--- a/tests/test_netbox_lists.py
+++ b/tests/test_netbox_lists.py
@@ -103,6 +103,8 @@ def nb_api():
     test_device_1_intf_1_ip_1 = nb_create(
         api.ipam.ip_addresses,
         address="192.0.2.1/24",
+        role="secondary",
+        dns_name="device-1.example.com",
         assigned_object_type="dcim.interface",
         assigned_object_id=test_device_1_intf_1.id,
     )
@@ -1072,6 +1074,108 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_primary_ip4": "",
                         "__meta_netbox_primary_ip6": "",
                         "__meta_netbox_fqdn": "",
+                    },
+                }
+            ],
+        ),
+        #
+        # IP Addresses SD
+        #
+        (
+            "http://localhost:8000/api/plugins/lists/prometheus-ip-addresses/",
+            [
+                {
+                    "targets": ["192.0.2.1"],
+                    "labels": {
+                        "__meta_netbox_role": "secondary",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "device-1.example.com",
+                    },
+                },
+                {
+                    "targets": ["2001:db8::1"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["192.0.2.2"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["2001:db8::1"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["192.0.2.5"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["2001:db8::dead:beef:1"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["192.0.2.3"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["2001:db8::3"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["192.0.2.4"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+            ],
+        ),
+        # Test a filter 	 	
+        (
+            "http://localhost:8000/api/plugins/lists/prometheus-ip-addresses/?device=Test-Device-2",
+            [
+                {
+                    "targets": ["192.0.2.2"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
+                    },
+                },
+                {
+                    "targets": ["2001:db8::1"],
+                    "labels": {
+                        "__meta_netbox_role": "",
+                        "__meta_netbox_status": "active",
+                        "__meta_netbox_dns_name": "",
                     },
                 }
             ],

--- a/tests/test_netbox_lists.py
+++ b/tests/test_netbox_lists.py
@@ -1090,6 +1090,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "secondary",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "device-1.example.com",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
                 {
@@ -1098,6 +1099,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
                 {
@@ -1106,6 +1108,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
                 {
@@ -1114,6 +1117,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
                 {
@@ -1122,6 +1126,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
                 {
@@ -1130,6 +1135,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
                 {
@@ -1138,6 +1144,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "eth0",
                     },
                 },
                 {
@@ -1146,6 +1153,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "eth0",
                     },
                 },
                 {
@@ -1154,6 +1162,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "eth1",
                     },
                 },
             ],
@@ -1168,6 +1177,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
                 {
@@ -1176,6 +1186,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_role": "",
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
+                        "__meta_netbox_assigned": "GigabitEthernet1/1",
                     },
                 },
             ],

--- a/tests/test_netbox_lists.py
+++ b/tests/test_netbox_lists.py
@@ -1158,7 +1158,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                 },
             ],
         ),
-        # Test a filter 	 	
+        # Test a filter
         (
             "http://localhost:8000/api/plugins/lists/prometheus-ip-addresses/?device=Test-Device-2",
             [
@@ -1177,7 +1177,7 @@ def test_lists_txt(nb_api: pynetbox.api, nb_requests: requests.Session):
                         "__meta_netbox_status": "active",
                         "__meta_netbox_dns_name": "",
                     },
-                }
+                },
             ],
         ),
     ],


### PR DESCRIPTION
This adds API endpoint `/api/plugins/lists/prometheus-ip-addresses/` that returns matching addresses as targets with labels. Suitable for prometheus http service discovery. It behaves similarly as prometheus device and VM endpoints.

Our use case is to have prometheus blackbox exporter ping all IP addresses on various interfaces. With this I can configure the endpoint to return the device and interface name as labels for each IP address that is assigned to a device.

Here is a sample response:

```json
# http://localhost:8000/api/plugins/lists/prometheus-ip-addresses/?assigned_to_interface=true
[
    {
        "targets": [
            "10.200.0.67/32"
        ],
        "labels": {
            "__meta_netbox_id": "655",
            "__meta_netbox_role": "loopback",
            "__meta_netbox_dns_name": "",
            "__meta_netbox_status": "active",
            "__meta_netbox_device": "r1.example.com",
            "__meta_netbox_interface": "Loopback0"
        }
    },
    {
        "targets": [
            "10.200.0.68/32"
        ],
        "labels": {
            "__meta_netbox_id": "660",
            "__meta_netbox_role": "loopback",
            "__meta_netbox_dns_name": "",
            "__meta_netbox_status": "active",
            "__meta_netbox_device": "r1.example.com",
            "__meta_netbox_interface": "Loopback0"
        }
    },
    {
        "targets": [
            "10.200.3.128/32"
        ],
        "labels": {
            "__meta_netbox_id": "640",
            "__meta_netbox_role": "",
            "__meta_netbox_dns_name": "",
            "__meta_netbox_status": "active",
            "__meta_netbox_device": "r1.example.com",
            "__meta_netbox_interface": "HundredGigE1/0/49"
        }
    }
]
```